### PR TITLE
Refactored as ES6 class to be used as a high-order component.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const RESERVED_PROPS = {
 
 export default (Component) => {
     invariant(
-        typeof Object.is(Component.handleChange, "function"),
+        Object.is(typeof Component.handleChange, "function"),
         "handleChange(propsList) is not a function."
     );
 


### PR DESCRIPTION
Here's a refactoring of react-side-effect as an ES6 class to resolve #4 .  I've used Babel to transpile, I can add npm scripts for this if you like.
