### PR TITLE
removing dependencies on react/lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var React = require('react'),
-    invariant = require('react/lib/invariant'),
-    shallowEqual = require('react/lib/shallowEqual');
+    invariant = require('fbjs/lib/invariant'),
+    shallowEqual = require('fbjs/lib/shallowEqual');
 
 function createSideEffect(onChange, mixin) {
   invariant(

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "bugs": {
     "url": "https://github.com/gaearon/react-side-effect/issues"
   },
-  "homepage": "https://github.com/gaearon/react-side-effect"
+  "homepage": "https://github.com/gaearon/react-side-effect",
+  "dependencies": {
+    "fbjs": "0.1.0-alpha.10"
+  }
 }


### PR DESCRIPTION
Hi,
this little PR just replaces `react/lib/invariant` and `react/lib/shallowEqual` by their counterpart on `fbjs/lib` to get compatibility with react 0.14. See #7 
