### PR TITLE
Remove dependency on fbjs and replace with more focused ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "homepage": "https://github.com/gaearon/react-side-effect",
   "dependencies": {
-    "fbjs": "0.1.0-alpha.10"
+    "exenv": "^1.2.1",
+    "shallowequal": "^0.2.2"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
-import shallowEqual from 'fbjs/lib/shallowEqual';
+import ExecutionEnvironment from 'exenv';
+import shallowEqual from 'shallowequal';
 
 module.exports = function withSideEffect(
   reducePropsToState,
-  handleStateChangeOnClient, 
+  handleStateChangeOnClient,
   mapStateOnServer
 ) {
   if (typeof reducePropsToState !== 'function') {
@@ -14,7 +14,7 @@ module.exports = function withSideEffect(
     throw new Error('Expected handleStateChangeOnClient to be a function.');
   }
   if (typeof mapStateOnServer !== 'undefined' && typeof mapStateOnServer !== 'function') {
-   throw new Error('Expected mapStateOnServer to either be undefined or a function.'); 
+   throw new Error('Expected mapStateOnServer to either be undefined or a function.');
   }
 
   function getDisplayName(WrappedComponent) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,7 +3,7 @@
 var expect = require('chai').expect;
 var React = require('react/addons');
 var TestUtils = React.addons.TestUtils;
-var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
+var ExecutionEnvironment = require('exenv');
 var withSideEffect = require('../src');
 var jsdom = require('jsdom');
 
@@ -210,6 +210,30 @@ describe('react-side-effect', function () {
 
         expect(sideEffect).to.be.ok;
         expect(sideEffect).to.have.deep.property('props.foo', 'bar');
+      });
+
+      it('should only recompute when component updates', function () {
+        var collectCount = 0;
+
+        function handleStateChangeOnClient(state) {
+          collectCount += 1;
+        }
+
+        SideEffect = withSideEffect(identity, handleStateChangeOnClient)(DummyComponent);
+
+        SideEffect.canUseDOM = true;
+
+        var node = document.createElement('div');
+        document.body.appendChild(node);
+
+        React.render(React.createElement(SideEffect, {text: 'bar'}), node);
+        expect(collectCount).to.equal(1);
+        React.render(React.createElement(SideEffect, {text: 'bar'}), node);
+        expect(collectCount).to.equal(1);
+        React.render(React.createElement(SideEffect, {text: 'baz'}), node);
+        expect(collectCount).to.equal(2);
+        React.render(React.createElement(SideEffect, {text: 'baz'}), node);
+        expect(collectCount).to.equal(2);
       });
     });
   });


### PR DESCRIPTION
I would have preferred a shallow comparison lib that had slightly lighter dependencies, but I couldn't find anything.

Do you reckon the core team would be open to spinning the shallow compare addon off into a standalone package?

Anyway, enjoy your holiday - no rush to merge this!
