### PR TITLE
Upgrades fbjs dependency to 0.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/gaearon/react-side-effect",
   "dependencies": {
-    "fbjs": "0.1.0-alpha.10"
+    "fbjs": "^0.8.6"
   },
   "devDependencies": {
     "babel": "^5.8.23",


### PR DESCRIPTION
This came up as an issue for me when trying to switch over a project to using [Yarn](https://yarnpkg.com/). `react` and `react-dom` declare the latest version of `fbjs` as their dependency, but this library, and its dependents like react-helmet, depend on a much older version. I was getting an exception thrown in my App render test (run with Jest) about not being able to find a certain functions from fbjs -- ones that were not present in `0.1.0-alpha.10`. Instead of trying to debug Yarn & Jest and how multiple versions of the same module are being resolved, I figured I'd just update the dependency version here.