### PR TITLE
Remove dependency on exenv by inlining the relevant parts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react": "^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "exenv": "^1.2.1",
     "shallowequal": "^1.0.1"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,7 @@ const config = {
       exclude: 'node_modules/**',
     }),
   ],
-  external: ['shallowequal', 'react', 'exenv'],
+  external: ['shallowequal', 'react'],
 }
 
 if (BUILD_FORMAT === 'umd') {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,11 @@
 import React, { Component } from 'react';
-import ExecutionEnvironment from 'exenv';
 import shallowEqual from 'shallowequal';
+
+const canUseDOM = !!(
+  typeof window !== 'undefined' &&
+  window.document &&
+  window.document.createElement
+);
 
 export default function withSideEffect(
   reducePropsToState,
@@ -46,7 +51,7 @@ export default function withSideEffect(
       static displayName = `SideEffect(${getDisplayName(WrappedComponent)})`;
 
       // Expose canUseDOM so tests can monkeypatch it
-      static canUseDOM = ExecutionEnvironment.canUseDOM;
+      static canUseDOM = canUseDOM;
 
       static peek() {
         return state;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,5 @@
 const { expect } = require('chai');
 const React = require('react');
-const ExecutionEnvironment = require('exenv');
 const jsdom = require('jsdom');
 const { shallow, mount } = require('enzyme')
 const { renderToStaticMarkup } = require('react-dom/server')
@@ -81,7 +80,7 @@ describe('react-side-effect', () => {
     });
 
     it('should expose the canUseDOM flag', () => {
-      expect(SideEffect).to.have.property('canUseDOM', ExecutionEnvironment.canUseDOM);
+      expect(SideEffect).to.have.property('canUseDOM');
     });
 
     describe('rewind', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,10 +1258,6 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-exenv@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.1.tgz#75de1c8dee02e952b102aa17f8875973e0df14f9"
-
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"


### PR DESCRIPTION
The exenv module is rather large because it's a UMD module and rollup can't inline it. It seems like it's also unmaintained (JedWatson/exenv#9 would adress this problem). This PR just inlines the relevant part.

Makes the minified UMD build 10% (0.11 kB) smaller. CJS and ESM builds are a couple bytes bigger but that should be well offset after bundling.