### PR TITLE
Restore support for React 16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "Louis DeScioli (https://descioli.design)"
   ],
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": "^16.3.0"
   },
   "dependencies": {
     "shallowequal": "^1.0.1"


### PR DESCRIPTION
The `UNSAFE_` aliases were introduced with React 16.3: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path

It's better to lower the React requirement as far as possible. This make it easier on downstream libraries and allows users to update `react-side-effect` before adopting React 16.9.