### PR TITLE
Use PureComponent and remove the dependency on shallowequal

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,6 @@
     "rimraf": "^2.4.3",
     "rollup": "^1.20.3",
     "rollup-plugin-babel": "^4.0.0",
-    "rollup-plugin-commonjs": "^8.3.0",
-    "rollup-plugin-node-resolve": "^3.0.3",
     "rollup-plugin-uglify": "^3.0.0"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
   "peerDependencies": {
     "react": "^16.9.0"
   },
-  "dependencies": {
-    "shallowequal": "^1.0.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "7.0.0",
     "@babel/core": "7.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,7 @@
 import babel from 'rollup-plugin-babel'
 import uglify from 'rollup-plugin-uglify'
-import resolve from 'rollup-plugin-node-resolve'
-import commonjs from 'rollup-plugin-commonjs'
 
-const { BUILD_ENV, BUILD_FORMAT } = process.env
+const { BUILD_ENV } = process.env
 
 const config = {
   input: 'src/index.js',
@@ -28,15 +26,6 @@ const config = {
     }),
   ],
   external: ['react'],
-}
-
-if (BUILD_FORMAT === 'umd') {
-  config.plugins.push(
-    resolve(),
-    commonjs({
-      include: /node_modules/,
-    }),
-  )
 }
 
 if (BUILD_ENV === 'production') {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,13 +27,10 @@ const config = {
       exclude: 'node_modules/**',
     }),
   ],
-  external: ['shallowequal', 'react'],
+  external: ['react'],
 }
 
 if (BUILD_FORMAT === 'umd') {
-  // In the browser build, include our smaller dependencies
-  // so users only need to include React
-  config.external = ['react']
   config.plugins.push(
     resolve(),
     commonjs({

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -33,10 +33,7 @@ const formats = [
 
 for (const { format, file, description, env } of formats) {
   console.log(`Building ${description}...`)
-  exec(`rollup -c -f ${format} -o ${file}`, {
-    BUILD_FORMAT: format,
-    ...env,
-  })
+  exec(`rollup -c -f ${format} -o ${file}`, env)
 }
 
 for (const { file, description } of formats) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-import React, { Component } from 'react';
-import shallowEqual from 'shallowequal';
+import React, { PureComponent } from 'react';
 
 const canUseDOM = !!(
   typeof window !== 'undefined' &&
@@ -46,7 +45,7 @@ export default function withSideEffect(
       }
     }
 
-    class SideEffect extends Component {
+    class SideEffect extends PureComponent {
       // Try to use displayName of wrapped component
       static displayName = `SideEffect(${getDisplayName(WrappedComponent)})`;
 
@@ -66,10 +65,6 @@ export default function withSideEffect(
         state = undefined;
         mountedInstances = [];
         return recordedState;
-      }
-
-      shouldComponentUpdate(nextProps) {
-        return !shallowEqual(nextProps, this.props);
       }
 
       UNSAFE_componentWillMount() {


### PR DESCRIPTION
Since `react-side-effect` 2.0 requires React 16, it can start using `PureComponent`. This brings the size of the minified UMD build down to 812 bytes - saving ~20% (0.2 KB).