### PR TITLE
Allow React 17 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "Louis DeScioli (https://descioli.design)"
   ],
   "peerDependencies": {
-    "react": "^16.3.0"
+    "react": "^16.3.0 || ^17.0.0"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Hi @gaearon, @lourd ! Thanks for this package!

Since `react-helmet` has a dependency on this package, I came here to bump the `peerDependencies` version of `react` to include `^17.0.0`, since I was getting these warnings:

```
warning "react-helmet > react-side-effect@2.1.0" has incorrect peer dependency "react@^16.3.0".
```