### PR TITLE
Allow React 18 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "Louis DeScioli (https://descioli.design)"
   ],
   "peerDependencies": {
-    "react": "^16.3.0 || ^17.0.0"
+    "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Same as #69 but for React 18 :) 

Like @karlhorky, I came here from a react-helmet warning:

```
npm WARN Conflicting peer dependency: react@17.0.2
npm WARN node_modules/react
npm WARN   peer react@"^16.3.0 || ^17.0.0" from react-side-effect@2.1.1
npm WARN   node_modules/react-helmet/node_modules/react-side-effect
npm WARN     react-side-effect@"^2.1.0" from react-helmet@6.1.0
npm WARN     node_modules/react-helmet
```

@lourd do you think we could write this peer dependency without upper bound, something like: `"react": ">=16.3.0"`?